### PR TITLE
[Feature/#93] sign-up page 구현

### DIFF
--- a/src/pages/signUp/SignUp.css.ts
+++ b/src/pages/signUp/SignUp.css.ts
@@ -1,0 +1,17 @@
+import { style } from '@vanilla-extract/css';
+import { vars } from '@shared/styles/theme.css';
+
+export const container = style({
+  padding: '0 2rem',
+
+  background: `var(--Linear, linear-gradient(180deg, ${vars.color.baroBlue} 0%, ${vars.color.blue8} 100%))`,
+});
+
+export const formContainer = style({
+  display: 'flex',
+  flexDirection: 'column',
+  justifyContent: 'center',
+
+  minHeight: '100vh',
+  gap: '3.4rem',
+});

--- a/src/pages/signUp/SignUp.tsx
+++ b/src/pages/signUp/SignUp.tsx
@@ -3,46 +3,38 @@ import SignUpInput from "./component/SignUpInput";
 import * as styles from "@pages/signUp/SignUp.css"
 import Button from "@shared/components/button/Button";
 import { useSignUpForm } from "./hook/useSignUpForm";
-import React, { useState } from "react";
+import { useState } from "react";
 import Text from "@shared/components/text/Text";
 
 export default function SignUp() {
   const [isEmailValid, setIsEmailValid] = useState(false);
-  const [emailAuthCode, setEmailAuthCode] = useState('');
-  const [emailAuthError, setEmailAuthError] = useState('');
   const [check, setCheck] = useState(false);
-  const { handleSubmit, errors, emailValue, passwordValue, nameValue, onSubmit, onSubmitError, onChangeEmail, onChangePassword, onChangeName, trigger } = useSignUpForm();
+  const { handleSubmit, errors, emailValue, passwordValue, nameValue, emailAuthCode, handleSubmitWithoutEmailAuth, onChangeEmail, onChangePassword, onChangeName, onChangeEmailAuthCode, trigger } = useSignUpForm();
   const handleCheckEmail = async () => {
     const isValid = await trigger('email');
     setIsEmailValid(isValid);
   };
-  const handleEmailAuthCodeChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setEmailAuthCode(e.target.value);
-  };
   const handleEmailAuthCodeSubmit = () => {
     if (emailAuthCode.trim() === '') {
       return;
-    } else if (emailAuthCode !== 'expectedCode') {
-      setEmailAuthError('인증번호가 일치하지 않습니다.');
+    } else if (emailAuthCode.trim() !== 'expectedCode') {
+      //TODO: api 연동
       return;
     }
-    setEmailAuthError('');
     setCheck(true);
   };
-  const EMAIL_ERROR = errors.email ? <Text color="red1">{errors.email.message}</Text> : null;
-  const PASSWORD_ERROR = errors.password ? <Text color="red1">{errors.password.message}</Text> : null;
-  const NAME_ERROR = errors.name ? <Text color="red1">{errors.name.message}</Text> : null;
+
   return (
     <Container className={styles.container}>
-      <form className={styles.formContainer} onSubmit={handleSubmit(onSubmit, onSubmitError)}>
+      <form className={styles.formContainer} onSubmit={handleSubmit(handleSubmitWithoutEmailAuth)}>
         <SignUpInput title = "이메일" placeholder="이메일을 입력해주세요" button buttonText="인증" onClick={handleCheckEmail} value={emailValue} onChange={onChangeEmail} />
-        {EMAIL_ERROR}
-        {isEmailValid && <SignUpInput title = "이메일 인증" placeholder="인증번호를 입력해주세요" button buttonText="확인" value={emailAuthCode} onChange={handleEmailAuthCodeChange} onClick={handleEmailAuthCodeSubmit}/>}
-        {emailAuthError && <Text color='red1'>{emailAuthError}</Text>}
+        {errors.email ? <Text color="red1">{errors.email.message}</Text> : null}
+        {isEmailValid && <SignUpInput title = "이메일 인증" placeholder="인증번호를 입력해주세요" button buttonText="확인" value={emailAuthCode} onChange={onChangeEmailAuthCode} onClick={handleEmailAuthCodeSubmit}/>}
+        {errors.emailAuthCode && <Text color='red1'>{errors.emailAuthCode.message}</Text>}
         <SignUpInput title = "비밀번호" placeholder="8자리 이상 입력해주세요" button={false} value={passwordValue} onChange={onChangePassword} />
-        {PASSWORD_ERROR}
+        {errors.password ? <Text color="red1">{errors.password.message}</Text> : null}
         <SignUpInput title = "이름" placeholder="사용할 이름을 입력해주세요(최대 8글자)" button={false} value={nameValue} onChange={onChangeName} />
-        {NAME_ERROR}
+        {errors.name ? <Text color="red1">{errors.name.message}</Text> : null}
         <Button variant={check ? "enabled" : "disabled"} size="long" text="회원가입" type="submit" />
       </form>
     </Container>

--- a/src/pages/signUp/SignUp.tsx
+++ b/src/pages/signUp/SignUp.tsx
@@ -1,48 +1,80 @@
-import Container from "@shared/components/container/Container";
-import SignUpInput from "./component/SignUpInput";
-import * as styles from "@pages/signUp/SignUp.css"
-import Button from "@shared/components/button/Button";
-import { useSignUpForm } from "./hook/useSignUpForm";
-import { useState } from "react";
-import Text from "@shared/components/text/Text";
+import Container from '@shared/components/container/Container';
+import SignUpInput from './component/SignUpInput';
+import * as styles from '@pages/signUp/SignUp.css';
+import Button from '@shared/components/button/Button';
+import { useSignUpForm } from './hook/useSignUpForm';
+import Text from '@shared/components/text/Text';
 
 export default function SignUp() {
-  const [isEmailValid, setIsEmailValid] = useState(false);
-  const [check, setCheck] = useState(false);
-  const { handleSubmit, errors, formData, handleSubmitWithoutEmailAuth, onChangeEmail, onChangePassword, onChangeName, onChangeEmailAuthCode, trigger } = useSignUpForm();
-  const handleCheckEmail = async () => {
-    const isValid = await trigger('email');
-    setIsEmailValid(isValid);
-  };
-  const handleEmailAuthCodeSubmit = () => {
-    if (formData.emailAuthCode.trim() === '') {
-      return;
-    } else if (formData.emailAuthCode.trim() !== 'expectedCode') {
-      //TODO: api 연동
-      return;
-    }
-    setCheck(true);
-  };
+  const {
+    handleSubmit,
+    errors,
+    formData,
+    handleSubmitWithoutEmailAuth,
+    handleFormChange,
+    check,
+    isEmailValid,
+    handleCheckEmail,
+    handleEmailAuthCodeSubmit,
+  } = useSignUpForm();
 
   return (
     <Container className={styles.container}>
-      <form className={styles.formContainer}  onSubmit={(e) => {
-        if (!check) {
-          e.preventDefault();
-          return;
-        }
-        return handleSubmit(handleSubmitWithoutEmailAuth)(e);
-      }}>
-        <SignUpInput title = "이메일" placeholder="이메일을 입력해주세요" button buttonText="인증" onClick={handleCheckEmail} value={formData.email} onChange={onChangeEmail} />
+      <form
+        className={styles.formContainer}
+        onSubmit={e => {
+          if (!check) {
+            e.preventDefault();
+            return;
+          }
+          return handleSubmit(handleSubmitWithoutEmailAuth)(e);
+        }}
+      >
+        <SignUpInput
+          title="이메일"
+          placeholder="이메일을 입력해주세요"
+          button
+          buttonText="인증"
+          onClick={handleCheckEmail}
+          value={formData.email}
+          onChange={handleFormChange('email')}
+        />
         {errors.email ? <Text color="red1">{errors.email.message}</Text> : null}
-        {isEmailValid && <SignUpInput title = "이메일 인증" placeholder="인증번호를 입력해주세요" button buttonText="확인" value={formData.emailAuthCode} onChange={onChangeEmailAuthCode} onClick={handleEmailAuthCodeSubmit}/>}
-        {errors.emailAuthCode && <Text color='red1'>{errors.emailAuthCode.message}</Text>}
-        <SignUpInput title = "비밀번호" placeholder="8자리 이상 입력해주세요" button={false} value={formData.password} onChange={onChangePassword} />
+        {isEmailValid && (
+          <SignUpInput
+            title="이메일 인증"
+            placeholder="인증번호를 입력해주세요"
+            button
+            buttonText="확인"
+            value={formData.emailAuthCode}
+            onChange={handleFormChange('emailAuthCode')}
+            onClick={handleEmailAuthCodeSubmit}
+          />
+        )}
+        {errors.emailAuthCode && <Text color="red1">{errors.emailAuthCode.message}</Text>}
+        <SignUpInput
+          title="비밀번호"
+          placeholder="8자리 이상 입력해주세요"
+          button={false}
+          value={formData.password}
+          onChange={handleFormChange('password')}
+        />
         {errors.password ? <Text color="red1">{errors.password.message}</Text> : null}
-        <SignUpInput title = "이름" placeholder="사용할 이름을 입력해주세요(최대 8글자)" button={false} value={formData.name} onChange={onChangeName} />
+        <SignUpInput
+          title="이름"
+          placeholder="사용할 이름을 입력해주세요(최대 8글자)"
+          button={false}
+          value={formData.name}
+          onChange={handleFormChange('name')}
+        />
         {errors.name ? <Text color="red1">{errors.name.message}</Text> : null}
-        <Button variant={check ? "enabled" : "disabled"} size="long" text="회원가입" type="submit" />
+        <Button
+          variant={check ? 'enabled' : 'disabled'}
+          size="long"
+          text="회원가입"
+          type="submit"
+        />
       </form>
     </Container>
-  )
+  );
 }

--- a/src/pages/signUp/SignUp.tsx
+++ b/src/pages/signUp/SignUp.tsx
@@ -9,15 +9,15 @@ import Text from "@shared/components/text/Text";
 export default function SignUp() {
   const [isEmailValid, setIsEmailValid] = useState(false);
   const [check, setCheck] = useState(false);
-  const { handleSubmit, errors, emailValue, passwordValue, nameValue, emailAuthCode, handleSubmitWithoutEmailAuth, onChangeEmail, onChangePassword, onChangeName, onChangeEmailAuthCode, trigger } = useSignUpForm();
+  const { handleSubmit, errors, formData, handleSubmitWithoutEmailAuth, onChangeEmail, onChangePassword, onChangeName, onChangeEmailAuthCode, trigger } = useSignUpForm();
   const handleCheckEmail = async () => {
     const isValid = await trigger('email');
     setIsEmailValid(isValid);
   };
   const handleEmailAuthCodeSubmit = () => {
-    if (emailAuthCode.trim() === '') {
+    if (formData.emailAuthCode.trim() === '') {
       return;
-    } else if (emailAuthCode.trim() !== 'expectedCode') {
+    } else if (formData.emailAuthCode.trim() !== 'expectedCode') {
       //TODO: api 연동
       return;
     }
@@ -33,13 +33,13 @@ export default function SignUp() {
         }
         return handleSubmit(handleSubmitWithoutEmailAuth)(e);
       }}>
-        <SignUpInput title = "이메일" placeholder="이메일을 입력해주세요" button buttonText="인증" onClick={handleCheckEmail} value={emailValue} onChange={onChangeEmail} />
+        <SignUpInput title = "이메일" placeholder="이메일을 입력해주세요" button buttonText="인증" onClick={handleCheckEmail} value={formData.email} onChange={onChangeEmail} />
         {errors.email ? <Text color="red1">{errors.email.message}</Text> : null}
-        {isEmailValid && <SignUpInput title = "이메일 인증" placeholder="인증번호를 입력해주세요" button buttonText="확인" value={emailAuthCode} onChange={onChangeEmailAuthCode} onClick={handleEmailAuthCodeSubmit}/>}
+        {isEmailValid && <SignUpInput title = "이메일 인증" placeholder="인증번호를 입력해주세요" button buttonText="확인" value={formData.emailAuthCode} onChange={onChangeEmailAuthCode} onClick={handleEmailAuthCodeSubmit}/>}
         {errors.emailAuthCode && <Text color='red1'>{errors.emailAuthCode.message}</Text>}
-        <SignUpInput title = "비밀번호" placeholder="8자리 이상 입력해주세요" button={false} value={passwordValue} onChange={onChangePassword} />
+        <SignUpInput title = "비밀번호" placeholder="8자리 이상 입력해주세요" button={false} value={formData.password} onChange={onChangePassword} />
         {errors.password ? <Text color="red1">{errors.password.message}</Text> : null}
-        <SignUpInput title = "이름" placeholder="사용할 이름을 입력해주세요(최대 8글자)" button={false} value={nameValue} onChange={onChangeName} />
+        <SignUpInput title = "이름" placeholder="사용할 이름을 입력해주세요(최대 8글자)" button={false} value={formData.name} onChange={onChangeName} />
         {errors.name ? <Text color="red1">{errors.name.message}</Text> : null}
         <Button variant={check ? "enabled" : "disabled"} size="long" text="회원가입" type="submit" />
       </form>

--- a/src/pages/signUp/SignUp.tsx
+++ b/src/pages/signUp/SignUp.tsx
@@ -1,0 +1,38 @@
+import Container from "@shared/components/container/Container";
+import SignUpInput from "./component/SignUpInput";
+import * as styles from "@pages/signUp/SignUp.css"
+import Button from "@shared/components/button/Button";
+import { useSignUpForm } from "./hook/useSignUpForm";
+import React, { useState } from "react";
+
+export default function SignUp() {
+  const [isEmailValid, setIsEmailValid] = useState(false);
+  const [emailAuthCode, setEmailAuthCode] = useState('');
+  const [check, setCheck] = useState(false);
+  const { handleSubmit, emailValue, passwordValue, nameValue, onSubmit, onSubmitError, onChangeEmail, onChangePassword, onChangeName, trigger } = useSignUpForm();
+  const handleCheckEmail = async () => {
+    const isValid = await trigger('email');
+    setIsEmailValid(isValid);
+  };
+  const handleEmailAuthCodeChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setEmailAuthCode(e.target.value);
+  };
+  const handleEmailAuthCodeSubmit = () => {
+    if (emailAuthCode.trim() === '') {
+      return;
+    }
+    setCheck(true);
+  };
+
+  return (
+    <Container className={styles.container}>
+      <form className={styles.formContainer} onSubmit={handleSubmit(onSubmit, onSubmitError)}>
+        <SignUpInput title = "이메일" placeholder="이메일을 입력해주세요" button buttonText="인증" onClick={handleCheckEmail} value={emailValue} onChange={onChangeEmail} />
+        {isEmailValid && <SignUpInput title = "이메일 인증" placeholder="인증번호를 입력해주세요" button buttonText="확인" value={emailAuthCode} onChange={handleEmailAuthCodeChange} onClick={handleEmailAuthCodeSubmit}/>}
+        <SignUpInput title = "비밀번호" placeholder="8자리 이상 입력해주세요" button={false} value={passwordValue} onChange={onChangePassword} />
+        <SignUpInput title = "이름" placeholder="사용할 이름을 입력해주세요(최대 8글자)" button={false} value={nameValue} onChange={onChangeName} />
+        <Button variant={check ? "enabled" : "disabled"} size="long" text="회원가입" onClick={handleSubmit(onSubmit, onSubmitError)} />
+      </form>
+    </Container>
+  )
+}

--- a/src/pages/signUp/SignUp.tsx
+++ b/src/pages/signUp/SignUp.tsx
@@ -26,7 +26,13 @@ export default function SignUp() {
 
   return (
     <Container className={styles.container}>
-      <form className={styles.formContainer} onSubmit={handleSubmit(handleSubmitWithoutEmailAuth)}>
+      <form className={styles.formContainer}  onSubmit={(e) => {
+        if (!check) {
+          e.preventDefault();
+          return;
+        }
+        return handleSubmit(handleSubmitWithoutEmailAuth)(e);
+      }}>
         <SignUpInput title = "이메일" placeholder="이메일을 입력해주세요" button buttonText="인증" onClick={handleCheckEmail} value={emailValue} onChange={onChangeEmail} />
         {errors.email ? <Text color="red1">{errors.email.message}</Text> : null}
         {isEmailValid && <SignUpInput title = "이메일 인증" placeholder="인증번호를 입력해주세요" button buttonText="확인" value={emailAuthCode} onChange={onChangeEmailAuthCode} onClick={handleEmailAuthCodeSubmit}/>}

--- a/src/pages/signUp/SignUp.tsx
+++ b/src/pages/signUp/SignUp.tsx
@@ -4,12 +4,14 @@ import * as styles from "@pages/signUp/SignUp.css"
 import Button from "@shared/components/button/Button";
 import { useSignUpForm } from "./hook/useSignUpForm";
 import React, { useState } from "react";
+import Text from "@shared/components/text/Text";
 
 export default function SignUp() {
   const [isEmailValid, setIsEmailValid] = useState(false);
   const [emailAuthCode, setEmailAuthCode] = useState('');
+  const [emailAuthError, setEmailAuthError] = useState('');
   const [check, setCheck] = useState(false);
-  const { handleSubmit, emailValue, passwordValue, nameValue, onSubmit, onSubmitError, onChangeEmail, onChangePassword, onChangeName, trigger } = useSignUpForm();
+  const { handleSubmit, errors, emailValue, passwordValue, nameValue, onSubmit, onSubmitError, onChangeEmail, onChangePassword, onChangeName, trigger } = useSignUpForm();
   const handleCheckEmail = async () => {
     const isValid = await trigger('email');
     setIsEmailValid(isValid);
@@ -20,18 +22,28 @@ export default function SignUp() {
   const handleEmailAuthCodeSubmit = () => {
     if (emailAuthCode.trim() === '') {
       return;
+    } else if (emailAuthCode !== 'expectedCode') {
+      setEmailAuthError('인증번호가 일치하지 않습니다.');
+      return;
     }
+    setEmailAuthError('');
     setCheck(true);
   };
-
+  const EMAIL_ERROR = errors.email ? <Text color="red1">{errors.email.message}</Text> : null;
+  const PASSWORD_ERROR = errors.password ? <Text color="red1">{errors.password.message}</Text> : null;
+  const NAME_ERROR = errors.name ? <Text color="red1">{errors.name.message}</Text> : null;
   return (
     <Container className={styles.container}>
       <form className={styles.formContainer} onSubmit={handleSubmit(onSubmit, onSubmitError)}>
         <SignUpInput title = "이메일" placeholder="이메일을 입력해주세요" button buttonText="인증" onClick={handleCheckEmail} value={emailValue} onChange={onChangeEmail} />
+        {EMAIL_ERROR}
         {isEmailValid && <SignUpInput title = "이메일 인증" placeholder="인증번호를 입력해주세요" button buttonText="확인" value={emailAuthCode} onChange={handleEmailAuthCodeChange} onClick={handleEmailAuthCodeSubmit}/>}
+        {emailAuthError && <Text color='red1'>{emailAuthError}</Text>}
         <SignUpInput title = "비밀번호" placeholder="8자리 이상 입력해주세요" button={false} value={passwordValue} onChange={onChangePassword} />
+        {PASSWORD_ERROR}
         <SignUpInput title = "이름" placeholder="사용할 이름을 입력해주세요(최대 8글자)" button={false} value={nameValue} onChange={onChangeName} />
-        <Button variant={check ? "enabled" : "disabled"} size="long" text="회원가입" onClick={handleSubmit(onSubmit, onSubmitError)} />
+        {NAME_ERROR}
+        <Button variant={check ? "enabled" : "disabled"} size="long" text="회원가입" type="submit" />
       </form>
     </Container>
   )

--- a/src/pages/signUp/component/SignUpInput.css.ts
+++ b/src/pages/signUp/component/SignUpInput.css.ts
@@ -1,0 +1,19 @@
+import { style } from '@vanilla-extract/css';
+
+export const container = style({
+  display: 'flex',
+  flexDirection: 'column',
+
+  gap: '1.1rem',
+});
+
+export const content = style({
+  display: 'flex',
+  justifyContent: 'space-between',
+
+  gap: '1.6rem',
+});
+
+export const dummy = style({
+  width: '8.9rem',
+});

--- a/src/pages/signUp/component/SignUpInput.tsx
+++ b/src/pages/signUp/component/SignUpInput.tsx
@@ -1,0 +1,27 @@
+import Button from "@shared/components/button/Button";
+import InputBar from "@shared/components/inputBar/InputBar";
+import Text from "@shared/components/text/Text";
+import * as styles from "@pages/signUp/component/SignUpInput.css";
+import React from "react";
+
+interface SignUpInputProps {
+  title: string;
+  buttonText?: string;
+  button: boolean;
+  placeholder?: string;
+  value?: string;
+  onChange?: (_e: React.ChangeEvent<HTMLInputElement>) => void;
+  onClick?: () => void;
+}
+
+export default function SignUpInput({ title, buttonText='', button = true, placeholder='', value='', onChange, onClick }: SignUpInputProps) {
+  return (
+    <div className={styles.container}>
+      <Text color="white" tag="body_bold_19">{title}</Text>
+      <div className={styles.content}>
+        <InputBar leftIcon="none" hasBackground={false} placeholder={placeholder} value={value} onChange={onChange} />
+        {button ? <Button variant="enabled" size="category" text={buttonText} onClick={onClick} /> : <div className={styles.dummy} />}
+      </div>
+    </div>
+  )
+}

--- a/src/pages/signUp/component/SignUpInput.tsx
+++ b/src/pages/signUp/component/SignUpInput.tsx
@@ -15,11 +15,12 @@ interface SignUpInputProps {
 }
 
 export default function SignUpInput({ title, buttonText='', button = true, placeholder='', value='', onChange, onClick }: SignUpInputProps) {
+
   return (
     <div className={styles.container}>
       <Text color="white" tag="body_bold_19">{title}</Text>
       <div className={styles.content}>
-        <InputBar leftIcon="none" hasBackground={false} placeholder={placeholder} value={value} onChange={onChange} />
+        <InputBar leftIcon="none" hasBackground={false} placeholder={placeholder} value={value} onChange={onChange} props={{...(title==="비밀번호"?{type:'password'}:{})}} />
         {button ? <Button variant="enabled" size="category" text={buttonText} onClick={onClick} /> : <div className={styles.dummy} />}
       </div>
     </div>

--- a/src/pages/signUp/hook/useSignUpForm.ts
+++ b/src/pages/signUp/hook/useSignUpForm.ts
@@ -8,7 +8,7 @@ const signUpSchema = z.object({
   emailAuthCode: z.string().nonempty('이메일 인증 코드를 입력해주세요.'),
   password: z
     .string()
-    .min(1, { message: '비밀번호를 입력해주세요.' })
+    .nonempty({ message: '비밀번호를 입력해주세요.' })
     .regex(/^(?=.*[a-zA-Z])(?=.*\d)(?=.*[!@#$%^&*]).{8,20}$/, {
       message: '문자와 특수문자, 숫자가 혼합된 8~20자리의 비밀번호를 입력해주세요.',
     }),
@@ -36,21 +36,18 @@ export function useSignUpForm() {
     mode: 'onSubmit',
   });
 
-  const emailValue = watch('email');
+  const formData = watch();
   const onChangeEmail = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setValue('email', e.target.value.trim(), { shouldValidate: true, shouldDirty: true });
+    setValue('email', e.target.value.trim());
   };
-  const emailAuthCode = watch('emailAuthCode');
   const onChangeEmailAuthCode = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setValue('emailAuthCode', e.target.value.trim(), { shouldValidate: true, shouldDirty: true });
+    setValue('emailAuthCode', e.target.value.trim());
   };
-  const passwordValue = watch('password');
   const onChangePassword = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setValue('password', e.target.value, { shouldValidate: true, shouldDirty: true });
+    setValue('password', e.target.value);
   };
-  const nameValue = watch('name');
   const onChangeName = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setValue('name', e.target.value.trim(), { shouldValidate: true, shouldDirty: true });
+    setValue('name', e.target.value.trim());
   };
   const handleSubmitWithoutEmailAuth = async () => {
     const isValid = await trigger(['email', 'password', 'name']);
@@ -59,25 +56,21 @@ export function useSignUpForm() {
       console.log('회원가입 데이터:', data);
     };
     if (isValid) {
-      // 해당 필드들만 추려서 form value 꺼내기
       const values = {
-        email: emailValue,
-        password: passwordValue,
-        name: nameValue,
+        email: formData.email,
+        password: formData.password,
+        name: formData.name,
       };
-      onSubmit(values); // 타입 단언 필요
+      onSubmit(values);
     } else {
-      //오류 처리
+      //TODO: 오류 처리
     }
   };
 
   return {
     handleSubmit,
     errors,
-    emailValue,
-    passwordValue,
-    nameValue,
-    emailAuthCode,
+    formData,
     onChangeEmail,
     onChangePassword,
     onChangeName,

--- a/src/pages/signUp/hook/useSignUpForm.ts
+++ b/src/pages/signUp/hook/useSignUpForm.ts
@@ -1,6 +1,6 @@
 import { useForm } from 'react-hook-form';
 import { z } from 'zod';
-import React from 'react';
+import React, { useState } from 'react';
 import { zodResolver } from '@hookform/resolvers/zod';
 
 const signUpSchema = z.object({
@@ -37,18 +37,27 @@ export function useSignUpForm() {
     mode: 'onSubmit',
   });
 
+  const [isEmailValid, setIsEmailValid] = useState(false);
+  const [check, setCheck] = useState(false);
+  const handleCheckEmail = async () => {
+    const isValid = await trigger('email');
+    setIsEmailValid(isValid);
+  };
+  const handleEmailAuthCodeSubmit = () => {
+    if (formData.emailAuthCode.trim() === '') {
+      return;
+    } else if (formData.emailAuthCode.trim() !== 'expectedCode') {
+      //TODO: api 연동
+      return;
+    }
+    setCheck(true);
+  };
   const formData = watch();
-  const onChangeEmail = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setValue('email', e.target.value.trim());
-  };
-  const onChangeEmailAuthCode = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setValue('emailAuthCode', e.target.value.trim());
-  };
-  const onChangePassword = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setValue('password', e.target.value);
-  };
-  const onChangeName = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setValue('name', e.target.value.trim());
+  const handleFormChange = (field: 'email' | 'password' | 'name' | 'emailAuthCode') => {
+    return function (e: React.ChangeEvent<HTMLInputElement>) {
+      const value = field === 'password' ? e.target.value : e.target.value.trim();
+      setValue(field, value, { shouldDirty: true, shouldValidate: true });
+    };
   };
   const handleSubmitWithoutEmailAuth = async () => {
     const isValid = await trigger(['email', 'password', 'name']);
@@ -72,11 +81,12 @@ export function useSignUpForm() {
     handleSubmit,
     errors,
     formData,
-    onChangeEmail,
-    onChangePassword,
-    onChangeName,
-    onChangeEmailAuthCode,
+    handleFormChange,
     handleSubmitWithoutEmailAuth,
     trigger,
+    check,
+    isEmailValid,
+    handleCheckEmail,
+    handleEmailAuthCodeSubmit,
   };
 }

--- a/src/pages/signUp/hook/useSignUpForm.ts
+++ b/src/pages/signUp/hook/useSignUpForm.ts
@@ -1,4 +1,4 @@
-import { useForm } from 'react-hook-form';
+import { useForm, type FieldErrors } from 'react-hook-form';
 import { z } from 'zod';
 import React from 'react';
 import { zodResolver } from '@hookform/resolvers/zod';
@@ -7,12 +7,10 @@ const signUpSchema = z.object({
   email: z.string().nonempty('이메일을 입력해주세요').email('이메일 형식이 올바르지 않습니다.'),
   password: z
     .string()
-    .min(8, { message: '비밀번호는 8자 이상이어야 합니다.' })
-    .max(20, { message: '비밀번호는 20자 이하여야 합니다.' })
-    .refine(val => val === '' || /^(?=.*[a-zA-Z])(?=.*\d)(?=.*[!@#$%^&*]).{8,20}$/.test(val), {
+    .min(1, { message: '비밀번호를 입력해주세요.' })
+    .regex(/^(?=.*[a-zA-Z])(?=.*\d)(?=.*[!@#$%^&*]).{8,20}$/, {
       message: '문자와 특수문자, 숫자가 혼합된 8~20자리의 비밀번호를 입력해주세요.',
-    })
-    .nonempty({ message: '비밀번호를 입력해주세요.' }),
+    }),
   name: z
     .string()
     .nonempty({ message: '이름을 입력해주세요.' })
@@ -21,18 +19,22 @@ const signUpSchema = z.object({
 export type SignUpFormValues = z.infer<typeof signUpSchema>;
 
 export function useSignUpForm() {
-  const { handleSubmit, formState, setFocus, watch, setValue, trigger } = useForm<SignUpFormValues>(
-    {
-      defaultValues: {
-        email: '',
-        password: '',
-        name: '',
-      },
-      resolver: zodResolver(signUpSchema),
-      mode: 'onSubmit',
-    }
-  );
-  const { errors } = formState;
+  const {
+    handleSubmit,
+    setFocus,
+    watch,
+    setValue,
+    trigger,
+    formState: { errors },
+  } = useForm<SignUpFormValues>({
+    defaultValues: {
+      email: '',
+      password: '',
+      name: '',
+    },
+    resolver: zodResolver(signUpSchema),
+    mode: 'onSubmit',
+  });
 
   const emailValue = watch('email');
   const onChangeEmail = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -40,7 +42,7 @@ export function useSignUpForm() {
   };
   const passwordValue = watch('password');
   const onChangePassword = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setValue('password', e.target.value.trim(), { shouldValidate: true, shouldDirty: true });
+    setValue('password', e.target.value, { shouldValidate: true, shouldDirty: true });
   };
   const nameValue = watch('name');
   const onChangeName = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -49,12 +51,12 @@ export function useSignUpForm() {
   const onSubmit = (data: SignUpFormValues) => {
     console.log('Form submitted:', data);
   };
-  const onSubmitError = () => {
-    if (errors.email) {
+  const onSubmitError = (formErrors: FieldErrors) => {
+    if (formErrors.email) {
       setFocus('email');
-    } else if (errors.password) {
+    } else if (formErrors.password) {
       setFocus('password');
-    } else if (errors.name) {
+    } else if (formErrors.name) {
       setFocus('name');
     }
   };
@@ -69,7 +71,7 @@ export function useSignUpForm() {
     onChangePassword,
     onChangeName,
     onSubmit,
-    onSubmitError,
     trigger,
+    onSubmitError,
   };
 }

--- a/src/pages/signUp/hook/useSignUpForm.ts
+++ b/src/pages/signUp/hook/useSignUpForm.ts
@@ -1,10 +1,11 @@
-import { useForm, type FieldErrors } from 'react-hook-form';
+import { useForm } from 'react-hook-form';
 import { z } from 'zod';
 import React from 'react';
 import { zodResolver } from '@hookform/resolvers/zod';
 
 const signUpSchema = z.object({
   email: z.string().nonempty('이메일을 입력해주세요').email('이메일 형식이 올바르지 않습니다.'),
+  emailAuthCode: z.string().nonempty('이메일 인증 코드를 입력해주세요.'),
   password: z
     .string()
     .min(1, { message: '비밀번호를 입력해주세요.' })
@@ -21,7 +22,6 @@ export type SignUpFormValues = z.infer<typeof signUpSchema>;
 export function useSignUpForm() {
   const {
     handleSubmit,
-    setFocus,
     watch,
     setValue,
     trigger,
@@ -40,6 +40,10 @@ export function useSignUpForm() {
   const onChangeEmail = (e: React.ChangeEvent<HTMLInputElement>) => {
     setValue('email', e.target.value.trim(), { shouldValidate: true, shouldDirty: true });
   };
+  const emailAuthCode = watch('emailAuthCode');
+  const onChangeEmailAuthCode = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setValue('emailAuthCode', e.target.value.trim(), { shouldValidate: true, shouldDirty: true });
+  };
   const passwordValue = watch('password');
   const onChangePassword = (e: React.ChangeEvent<HTMLInputElement>) => {
     setValue('password', e.target.value, { shouldValidate: true, shouldDirty: true });
@@ -48,16 +52,21 @@ export function useSignUpForm() {
   const onChangeName = (e: React.ChangeEvent<HTMLInputElement>) => {
     setValue('name', e.target.value.trim(), { shouldValidate: true, shouldDirty: true });
   };
-  const onSubmit = (data: SignUpFormValues) => {
-    console.log('Form submitted:', data);
-  };
-  const onSubmitError = (formErrors: FieldErrors) => {
-    if (formErrors.email) {
-      setFocus('email');
-    } else if (formErrors.password) {
-      setFocus('password');
-    } else if (formErrors.name) {
-      setFocus('name');
+  const handleSubmitWithoutEmailAuth = async () => {
+    const isValid = await trigger(['email', 'password', 'name']);
+    const onSubmit = (data: Pick<SignUpFormValues, 'email' | 'password' | 'name'>) => {
+      //TODO: api 연동
+    };
+    if (isValid) {
+      // 해당 필드들만 추려서 form value 꺼내기
+      const values = {
+        email: emailValue,
+        password: passwordValue,
+        name: nameValue,
+      };
+      onSubmit(values); // 타입 단언 필요
+    } else {
+      //오류 처리
     }
   };
 
@@ -67,11 +76,12 @@ export function useSignUpForm() {
     emailValue,
     passwordValue,
     nameValue,
+    emailAuthCode,
     onChangeEmail,
     onChangePassword,
     onChangeName,
-    onSubmit,
+    onChangeEmailAuthCode,
+    handleSubmitWithoutEmailAuth,
     trigger,
-    onSubmitError,
   };
 }

--- a/src/pages/signUp/hook/useSignUpForm.ts
+++ b/src/pages/signUp/hook/useSignUpForm.ts
@@ -1,0 +1,75 @@
+import { useForm } from 'react-hook-form';
+import { z } from 'zod';
+import React from 'react';
+import { zodResolver } from '@hookform/resolvers/zod';
+
+const signUpSchema = z.object({
+  email: z.string().nonempty('이메일을 입력해주세요').email('이메일 형식이 올바르지 않습니다.'),
+  password: z
+    .string()
+    .min(8, { message: '비밀번호는 8자 이상이어야 합니다.' })
+    .max(20, { message: '비밀번호는 20자 이하여야 합니다.' })
+    .refine(val => val === '' || /^(?=.*[a-zA-Z])(?=.*\d)(?=.*[!@#$%^&*]).{8,20}$/.test(val), {
+      message: '문자와 특수문자, 숫자가 혼합된 8~20자리의 비밀번호를 입력해주세요.',
+    })
+    .nonempty({ message: '비밀번호를 입력해주세요.' }),
+  name: z
+    .string()
+    .nonempty({ message: '이름을 입력해주세요.' })
+    .max(8, { message: '이름은 최대 8자까지 입력할 수 있습니다.' }),
+});
+export type SignUpFormValues = z.infer<typeof signUpSchema>;
+
+export function useSignUpForm() {
+  const { handleSubmit, formState, setFocus, watch, setValue, trigger } = useForm<SignUpFormValues>(
+    {
+      defaultValues: {
+        email: '',
+        password: '',
+        name: '',
+      },
+      resolver: zodResolver(signUpSchema),
+      mode: 'onSubmit',
+    }
+  );
+  const { errors } = formState;
+
+  const emailValue = watch('email');
+  const onChangeEmail = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setValue('email', e.target.value.trim(), { shouldValidate: true, shouldDirty: true });
+  };
+  const passwordValue = watch('password');
+  const onChangePassword = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setValue('password', e.target.value.trim(), { shouldValidate: true, shouldDirty: true });
+  };
+  const nameValue = watch('name');
+  const onChangeName = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setValue('name', e.target.value.trim(), { shouldValidate: true, shouldDirty: true });
+  };
+  const onSubmit = (data: SignUpFormValues) => {
+    console.log('Form submitted:', data);
+  };
+  const onSubmitError = () => {
+    if (errors.email) {
+      setFocus('email');
+    } else if (errors.password) {
+      setFocus('password');
+    } else if (errors.name) {
+      setFocus('name');
+    }
+  };
+
+  return {
+    handleSubmit,
+    errors,
+    emailValue,
+    passwordValue,
+    nameValue,
+    onChangeEmail,
+    onChangePassword,
+    onChangeName,
+    onSubmit,
+    onSubmitError,
+    trigger,
+  };
+}

--- a/src/pages/signUp/hook/useSignUpForm.ts
+++ b/src/pages/signUp/hook/useSignUpForm.ts
@@ -56,6 +56,7 @@ export function useSignUpForm() {
     const isValid = await trigger(['email', 'password', 'name']);
     const onSubmit = (data: Pick<SignUpFormValues, 'email' | 'password' | 'name'>) => {
       //TODO: api 연동
+      console.log('회원가입 데이터:', data);
     };
     if (isValid) {
       // 해당 필드들만 추려서 form value 꺼내기

--- a/src/pages/signUp/hook/useSignUpForm.ts
+++ b/src/pages/signUp/hook/useSignUpForm.ts
@@ -29,6 +29,7 @@ export function useSignUpForm() {
   } = useForm<SignUpFormValues>({
     defaultValues: {
       email: '',
+      emailAuthCode: '',
       password: '',
       name: '',
     },

--- a/src/router/Router.tsx
+++ b/src/router/Router.tsx
@@ -2,7 +2,6 @@ import { createBrowserRouter } from 'react-router-dom';
 import { lazy } from 'react';
 import { ROUTES } from '@router/constant/Routes';
 import Layout from './Layout';
-import SignUp from '@pages/signUp/SignUp';
 
 const NotFound = lazy(() => import('@shared/components/notFound/NotFound'));
 const Home = lazy(() => import('@pages/home/Home'));
@@ -11,7 +10,7 @@ const MyPage = lazy(() => import('@pages/myPage/MyPage'));
 const Search = lazy(() => import('@pages/search/Search'));
 const Promise = lazy(() => import('@pages/promise/Promise'));
 const PromiseStatus = lazy(() => import('@pages/promiseStatus/PromiseStatus'));
-
+const SignUp = lazy(() => import('@pages/signUp/SignUp'));
 const router = createBrowserRouter([
   {
     element: <Layout />,

--- a/src/router/Router.tsx
+++ b/src/router/Router.tsx
@@ -2,6 +2,7 @@ import { createBrowserRouter } from 'react-router-dom';
 import { lazy } from 'react';
 import { ROUTES } from '@router/constant/Routes';
 import Layout from './Layout';
+import SignUp from '@pages/signUp/SignUp';
 
 const NotFound = lazy(() => import('@shared/components/notFound/NotFound'));
 const Home = lazy(() => import('@pages/home/Home'));
@@ -38,6 +39,10 @@ const router = createBrowserRouter([
       {
         path: ROUTES.PROMISE_STATUS,
         element: <PromiseStatus />,
+      },
+      {
+        path: ROUTES.SIGN_UP,
+        element: <SignUp />,
       },
       {
         path: '*',

--- a/src/router/constant/Routes.ts
+++ b/src/router/constant/Routes.ts
@@ -5,4 +5,5 @@ export const ROUTES = {
   SEARCH: '/search',
   PROMISE: '/promise',
   PROMISE_STATUS: '/promise-status',
+  SIGN_UP: '/sign-up',
 };

--- a/src/shared/components/button/Button.tsx
+++ b/src/shared/components/button/Button.tsx
@@ -13,17 +13,24 @@ interface ButtonProps {
   text: string;
   onClick?: () => void;
   backgroundColor?: string;
+  type?: 'button' | 'submit' | 'reset';
 }
 
-const Button = ({ variant, size, text, onClick, backgroundColor }: ButtonProps) => {
-  const textColor =
-    size === BUTTON_SIZES.SMALL && backgroundColor
-      ? backgroundColor === vars.color.white
-        ? vars.color.baroBlue
-        : backgroundColor === vars.color.baroBlue
-          ? vars.color.white
-          : undefined
-      : undefined;
+const Button = ({
+  variant,
+  size,
+  text,
+  onClick,
+  backgroundColor,
+  type = 'button',
+}: ButtonProps) => {
+  const textColor = size === BUTTON_SIZES.SMALL && backgroundColor
+    ? backgroundColor === vars.color.white
+      ? vars.color.baroBlue
+      : backgroundColor === vars.color.baroBlue
+        ? vars.color.white
+        : undefined
+    : undefined;
 
   const customStyle =
     backgroundColor && variant === BUTTON_VARIANTS.ENABLED
@@ -38,6 +45,7 @@ const Button = ({ variant, size, text, onClick, backgroundColor }: ButtonProps) 
       className={styles.buttonWrapper({ variant, size })}
       style={customStyle}
       onClick={onClick}
+      type={type}
     >
       {text}
     </button>


### PR DESCRIPTION
## 📌 Related Issues

<!--관련 이슈 언급 -->

- close #93

## ✅ 체크 리스트

- [X] PR 제목의 형식을 잘 작성했나요? e.g. [Feat/#이슈번호] PR 템플릿 작성
- [ ] 빌드가 성공했나요? (pnpm build)
- [X] 컨벤션을 지켰나요?
- [X] 이슈는 등록했나요?
- [X] 리뷰어와 라벨을 지정했나요?

## 📄 Tasks

sign up 페이지 구현완료했습니다.

## ⭐ PR Point (To Reviewer)

정현님 review를 보고 form filed 자체를 컴포넌트로 구현할 필요가 없다고 생각이 들었습니다. 그래서 Signup 페이지 안에 넣는 방식을 택했고 이게 괜찮으면 앞의 로그인 페이지도 구현을 그렇게 바꾸겠습니다.
이메일 인증 부분까지 zod에 들어간다면 후에 api 연결할 때 애매할 거 같아서 
따로 빼서 구현을 실시했습니다. 이 부분은 trigger를 통해 email만 인증하는 로직을 택했습니다.
동희님 pr 에서 onChange부분을 떼와서 살짝 변형시켜서 넣었습니다.

## 📷 Screenshot

<!-- 작업 결과물에 관련된 사진이나 영상 등을 첨부해주세요 -->
<img width="421" height="543" alt="스크린샷 2025-08-13 오후 4 57 55" src="https://github.com/user-attachments/assets/63d63574-b076-4e6c-844c-3919d1e2a845" />
<img width="453" height="488" alt="스크린샷 2025-08-13 오후 4 58 02" src="https://github.com/user-attachments/assets/6c0fc634-f872-49e6-8866-7ccade11c16c" />

## 🔔 ETC

<!-- 기타 이외 작업 작성 (ex. 참고한 아티클 링크 / 새롭게 알게 된 점 등) -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - 회원가입 페이지 추가: 이메일 유효성 검사, 인증코드 입력/확인, 비밀번호·이름 입력 및 인증 완료 시 가입 버튼 활성화.
  - 라우터에 회원가입 경로(/sign-up) 추가로 페이지 접근 가능.
  - 폼 훅 추가: 검증 규칙(이메일, 인증코드, 비밀번호, 이름), 필드 상태·제출/인증 흐름 제공.
  - 입력 컴포넌트(SignUpInput) 추가: 제목, 입력창, 선택적 버튼 제공.

- **Style**
  - 회원가입 페이지 및 입력 컴포넌트용 스타일 추가(배경, 레이아웃, 간격).

- **Chores**
  - 공용 버튼에 type 속성(button/submit/reset) 추가.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->